### PR TITLE
wsdl document url generate from host rather than localhost

### DIFF
--- a/fastapi_soap/routes.py
+++ b/fastapi_soap/routes.py
@@ -87,8 +87,8 @@ class SoapRouter(APIRouter):
             '/', self._generate_wsdl, methods=['GET'], status_code=200
         )
 
-    def _generate_wsdl(self):
-        wsdl = generate_wsdl(self._name, self._methods, url=self.prefix)
+    def _generate_wsdl(self, request: Request):
+        wsdl = generate_wsdl(self._name, self._methods, url=self.prefix, request=request)
         return SoapResponse(dump_etree(wsdl), envelope_wrap=False)
 
     def operation(

--- a/fastapi_soap/wsdl.py
+++ b/fastapi_soap/wsdl.py
@@ -2,6 +2,7 @@ from typing import Optional
 from xml.etree import ElementTree as ET
 from xml.etree.ElementTree import Element, SubElement, tostring
 
+from fastapi import Request
 from pydantic.fields import ModelField
 from pydantic.typing import display_as_type
 from pydantic_xml import BaseXmlModel, XmlElementInfo
@@ -99,7 +100,7 @@ def dump_etree(element: Element) -> str:
 
 
 def generate_wsdl(
-    name: str, methods, url: str, documentation: str = ''
+    name: str, methods, url: str, request: Request, documentation: str = ''
 ) -> Element:
     wsdl = Element('wsdl:definitions', nsmap, name=name)
     SubElement(wsdl, 'wsdl:documentation').text = documentation
@@ -139,7 +140,7 @@ def generate_wsdl(
         SubElement(
             port_element,
             'soap:address',
-            location=f'http://localhost:8000{url}/{method}',
+            location=f'http://{request.headers.get("host")}{url}/{method}',
         )
 
         for action, model in models.items():


### PR DESCRIPTION
wsdl docment url address location change according to request `host` and `port`

Current wsdl docment address location is fixed at `http://localhost:8000` no matter where you send http request to `127.0.0.1`, or send from third hosts.
This behavior will cause generating wrong `soap post url` using soap tools like `soapui`.
```
<wsdl:service name="Calculator">
<wsdl:port name="CalculatorSumOperation" binding="CalculatorSumOperation">
<soap:address location="http://localhost:8000/Calculator/SumOperation"/>
</wsdl:port>
</wsdl:service>
```
This commit will change wsdl address location url according to request host.
When you request to `http://host:port`, the `wsdl document address location url` will be convert to `http://host:port` rather than `http://localhost:8000`.

When `soap` service deploy on other host, ip,port say `192.168.1.1:5000`, the `wsdl docment address localhost url` will be:
```
<wsdl:service name="Calculator">
<wsdl:port name="CalculatorSumOperation" binding="CalculatorSumOperation">
<soap:address location="http://192.168.1.1:5000/Calculator/SumOperation"/>
</wsdl:port>
</wsdl:service>
```